### PR TITLE
Fix "Deprecated: Non-static method should not be called statically"

### DIFF
--- a/src/Mapping/Driver/AnnotationDriver.php
+++ b/src/Mapping/Driver/AnnotationDriver.php
@@ -207,7 +207,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             ->setMiddleware($annotation->getMiddleware())
             ->setMethods($annotation->getMethods())
             ->setXmlHttpRequest($annotation->isXmlHttpRequest())
-            ->setInvokable([$class->name,  $method->name])
+            ->setInvokable($class->name . ':' . $method->name)
             ->setPriority($annotation->getPriority());
 
         if ($annotation->getPattern() !== null) {

--- a/src/Mapping/Driver/MappingTrait.php
+++ b/src/Mapping/Driver/MappingTrait.php
@@ -97,7 +97,7 @@ trait MappingTrait
      *
      * @return RouteMetadata
      */
-    protected function getRouteMetadata(array $mapping, GroupMetadata $group = null): RouteMetadata
+    protected function getRouteMetadata($mapping, GroupMetadata $group = null): RouteMetadata
     {
         $route = (new RouteMetadata())
             ->setMethods($this->getMethods($mapping))
@@ -347,7 +347,7 @@ trait MappingTrait
      *
      * @return string|array|callable
      */
-    protected function getInvokable(array $mapping)
+    protected function getInvokable($mapping)
     {
         if (!\array_key_exists('invokable', $mapping)) {
             throw new DriverException('Route invokable definition missing');

--- a/src/Mapping/Driver/MappingTrait.php
+++ b/src/Mapping/Driver/MappingTrait.php
@@ -347,7 +347,7 @@ trait MappingTrait
      *
      * @return string|array|callable
      */
-    protected function getInvokable($mapping)
+    protected function getInvokable(array $mapping)
     {
         if (!\array_key_exists('invokable', $mapping)) {
             throw new DriverException('Route invokable definition missing');

--- a/tests/Routing/Mapping/Driver/AnnotationDriverTest.php
+++ b/tests/Routing/Mapping/Driver/AnnotationDriverTest.php
@@ -134,7 +134,7 @@ class AnnotationDriverTest extends TestCase
         self::assertEquals('four', $route->getName());
         self::assertEquals(['GET'], $route->getMethods());
         self::assertEquals(
-            ['Jgut\Slim\Routing\Tests\Files\Annotation\Valid\DependentRoute', 'actionFour'],
+            'Jgut\Slim\Routing\Tests\Files\Annotation\Valid\DependentRoute:actionFour',
             $route->getInvokable()
         );
         self::assertEquals(0, $route->getPriority());
@@ -147,7 +147,7 @@ class AnnotationDriverTest extends TestCase
         self::assertNull($route->getName());
         self::assertEquals(['GET'], $route->getMethods());
         self::assertEquals(
-            ['Jgut\Slim\Routing\Tests\Files\Annotation\Valid\GroupedRoute', 'actionTwo'],
+            'Jgut\Slim\Routing\Tests\Files\Annotation\Valid\GroupedRoute:actionTwo',
             $route->getInvokable()
         );
         self::assertEquals(0, $route->getPriority());
@@ -160,7 +160,7 @@ class AnnotationDriverTest extends TestCase
         self::assertNull($route->getName());
         self::assertEquals(['GET'], $route->getMethods());
         self::assertEquals(
-            ['Jgut\Slim\Routing\Tests\Files\Annotation\Valid\GroupedRoute', 'actionThree'],
+            'Jgut\Slim\Routing\Tests\Files\Annotation\Valid\GroupedRoute:actionThree',
             $route->getInvokable()
         );
         self::assertEquals(0, $route->getPriority());
@@ -173,7 +173,7 @@ class AnnotationDriverTest extends TestCase
         self::assertEquals('one', $route->getName());
         self::assertEquals(['GET', 'POST'], $route->getMethods());
         self::assertEquals(
-            ['Jgut\Slim\Routing\Tests\Files\Annotation\Valid\SingleRoute', 'actionOne'],
+            'Jgut\Slim\Routing\Tests\Files\Annotation\Valid\SingleRoute:actionOne',
             $route->getInvokable()
         );
         self::assertEquals(-10, $route->getPriority());

--- a/tests/Routing/Mapping/Driver/MappingTraitTest.php
+++ b/tests/Routing/Mapping/Driver/MappingTraitTest.php
@@ -166,7 +166,7 @@ class MappingTraitTest extends TestCase
                                     'methods' => ['GET'],
                                     'pattern' => '/four',
                                     'middleware' => ['fourMiddleware'],
-                                    'invokable' => ['FourRoute', 'actionFour'],
+                                    'invokable' => 'FourRoute' . ':' . 'actionFour',
                                 ],
                             ],
                         ],
@@ -183,7 +183,7 @@ class MappingTraitTest extends TestCase
                             'methods' => ['GET'],
                             'pattern' => '/two/{id}',
                             'middleware' => ['twoMiddleware'],
-                            'invokable' => ['TwoRoute', 'actionTwo'],
+                            'invokable' => 'TwoRoute' . ':' . 'actionTwo',
                         ],
                         [
                             'methods' => ['GET'],
@@ -191,7 +191,7 @@ class MappingTraitTest extends TestCase
                             'placeholders' => [
                                 'id' => '\d+',
                             ],
-                            'invokable' => ['ThreeRoute', 'actionThree'],
+                            'invokable' => 'ThreeRoute' . ':' . 'actionThree',
                         ],
                     ],
                 ],
@@ -208,7 +208,7 @@ class MappingTraitTest extends TestCase
                         'id' => 'int',
                     ],
                     'middleware' => ['oneMiddleware'],
-                    'invokable' => ['OneRoute', 'actionOne'],
+                    'invokable' => 'OneRoute' . ':' . 'actionOne',
                 ],
             ]));
         /* @var \Jgut\Mapping\Driver\AbstractMappingDriver $driver */
@@ -220,7 +220,7 @@ class MappingTraitTest extends TestCase
         self::assertEquals('four', $route->getName());
         self::assertEquals(['GET'], $route->getMethods());
         self::assertEquals(0, $route->getPriority());
-        self::assertEquals(['FourRoute', 'actionFour'], $route->getInvokable());
+        self::assertEquals('FourRoute' . ':' . 'actionFour', $route->getInvokable());
         self::assertEquals('four', $route->getPattern());
         self::assertEquals([], $route->getPlaceholders());
         self::assertEquals(['fourMiddleware'], $route->getMiddleware());
@@ -230,7 +230,7 @@ class MappingTraitTest extends TestCase
         self::assertNull($route->getName());
         self::assertEquals(['GET'], $route->getMethods());
         self::assertEquals(0, $route->getPriority());
-        self::assertEquals(['TwoRoute', 'actionTwo'], $route->getInvokable());
+        self::assertEquals('TwoRoute' . ':' . 'actionTwo', $route->getInvokable());
         self::assertEquals('two/{id}', $route->getPattern());
         self::assertEquals([], $route->getPlaceholders());
         self::assertEquals(['twoMiddleware'], $route->getMiddleware());
@@ -239,7 +239,7 @@ class MappingTraitTest extends TestCase
         self::assertInstanceOf(RouteMetadata::class, $route);
         self::assertEquals('', $route->getName());
         self::assertEquals(['GET'], $route->getMethods());
-        self::assertEquals(['ThreeRoute', 'actionThree'], $route->getInvokable());
+        self::assertEquals('ThreeRoute' . ':' . 'actionThree', $route->getInvokable());
         self::assertEquals(0, $route->getPriority());
         self::assertEquals('three/{id}', $route->getPattern());
         self::assertEquals(['id' => '\d+'], $route->getPlaceholders());
@@ -250,7 +250,7 @@ class MappingTraitTest extends TestCase
         self::assertEquals('one', $route->getName());
         self::assertEquals(['GET', 'POST'], $route->getMethods());
         self::assertEquals(-10, $route->getPriority());
-        self::assertEquals(['OneRoute', 'actionOne'], $route->getInvokable());
+        self::assertEquals('OneRoute' . ':' . 'actionOne', $route->getInvokable());
         self::assertEquals('one/{id}', $route->getPattern());
         self::assertEquals(['id' => 'numeric'], $route->getPlaceholders());
         self::assertEquals(['oneMiddleware'], $route->getMiddleware());


### PR DESCRIPTION
When writing classes like in your examples:

```php
use Jgut\Slim\Routing\Mapping\Annotation as JSR;

/**
 * @JSR\Router
 */
class Controller
{
    /**
     * @JSR\Route(pattern="/hello")
     */
    public function doSomething()
    {
    }
}
```  
we would get errors like `Deprecated: Non-static method should not be called statically`, as a workaround we would just make all the methods static, which worked.

But we also had the problem that we wanted to write Controller Classes, which get a reference to the Container injected. 

Because of this, I changed the format in which the class and method gets handed over to Slim, to the way to this [section in the documentation](https://www.slimframework.com/docs/v3/objects/router.html#container-resolution) describes how it should be done ("Class:method").

Also please note that we are using PHP 7.2.
